### PR TITLE
Log cache

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,7 +33,7 @@ func (r *Rafty) submitCommandWrite(timeout time.Duration, command []byte) ([]byt
 		select {
 		case r.triggerAppendEntriesChan <- triggerAppendEntries{command: command, responseChan: responseChan}:
 		case <-time.After(timeout):
-			return nil, ErrTimeoutSendingRequest
+			return nil, ErrTimeout
 		}
 
 		// answer back to the client
@@ -45,7 +45,7 @@ func (r *Rafty) submitCommandWrite(timeout time.Duration, command []byte) ([]byt
 			return nil, ErrShutdown
 
 		case <-time.After(timeout):
-			return nil, ErrTimeoutSendingRequest
+			return nil, ErrTimeout
 		}
 	}
 
@@ -102,7 +102,7 @@ func (r *Rafty) submitCommandReadLeader(timeout time.Duration, command []byte) (
 			return nil, ErrShutdown
 
 		case <-ctx.Done():
-			return nil, ErrTimeoutSendingRequest
+			return nil, ErrTimeout
 		}
 	}
 
@@ -133,7 +133,7 @@ func (r *Rafty) submitCommandReadStale(timeout time.Duration, command []byte) ([
 		return nil, ErrShutdown
 
 	case <-ctx.Done():
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }
 
@@ -176,7 +176,7 @@ func (r *Rafty) BootstrapCluster(timeout time.Duration) error {
 		ResponseChan: responseChan,
 	}:
 	case <-time.After(timeout):
-		return ErrTimeoutSendingRequest
+		return ErrTimeout
 	}
 
 	select {
@@ -187,7 +187,7 @@ func (r *Rafty) BootstrapCluster(timeout time.Duration) error {
 		return ErrShutdown
 
 	case <-time.After(timeout):
-		return ErrTimeoutSendingRequest
+		return ErrTimeout
 	}
 }
 
@@ -234,7 +234,7 @@ func (r *Rafty) manageMembers(timeout time.Duration, action MembershipChange, ad
 		ResponseChan: responseChan,
 	}:
 	case <-time.After(timeout):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 
 	select {
@@ -245,7 +245,7 @@ func (r *Rafty) manageMembers(timeout time.Duration, action MembershipChange, ad
 		return nil, ErrShutdown
 
 	case <-time.After(timeout):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -117,7 +117,7 @@ func TestClient_submitCommand(t *testing.T) {
 		assert.Nil(EncodeCommand(Command{Kind: CommandSet, Key: fmt.Sprintf("key%s", s.id)}, buffer))
 
 		_, err := s.submitCommandWrite(time.Second, buffer.Bytes())
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 	})
 
 	t.Run("write_response", func(t *testing.T) {
@@ -195,7 +195,7 @@ func TestClient_submitCommand(t *testing.T) {
 		assert.Nil(EncodeCommand(Command{Kind: CommandSet, Key: fmt.Sprintf("key%s", s.id)}, buffer))
 
 		_, err := s.submitCommandWrite(time.Second, buffer.Bytes())
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 	})
 
 	t.Run("write_forward_command_error", func(t *testing.T) {
@@ -266,7 +266,7 @@ func TestClient_submitCommand(t *testing.T) {
 		assert.Nil(EncodeCommand(Command{Kind: CommandSet, Key: fmt.Sprintf("key%s", s.id)}, buffer))
 
 		_, err := s.submitCommandReadLeader(time.Second, buffer.Bytes())
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 	})
 
 	t.Run("read_no_leader_error", func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestClient_submitCommand(t *testing.T) {
 		assert.Nil(EncodeCommand(Command{Kind: CommandSet, Key: fmt.Sprintf("key%s", s.id)}, buffer))
 
 		_, err := s.submitCommandReadStale(time.Second, buffer.Bytes())
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 	})
 }
 
@@ -432,7 +432,7 @@ func TestClient_bootstrapCluster(t *testing.T) {
 			s.stopCtx()
 		}()
 
-		assert.ErrorIs(s.BootstrapCluster(time.Millisecond), ErrTimeoutSendingRequest)
+		assert.ErrorIs(s.BootstrapCluster(time.Millisecond), ErrTimeout)
 		s.wg.Wait()
 	})
 
@@ -495,7 +495,7 @@ func TestClient_bootstrapCluster(t *testing.T) {
 			time.Sleep(2 * time.Second)
 		}()
 
-		assert.ErrorIs(s.BootstrapCluster(time.Second), ErrTimeoutSendingRequest)
+		assert.ErrorIs(s.BootstrapCluster(time.Second), ErrTimeout)
 		s.wg.Wait()
 	})
 }
@@ -522,7 +522,7 @@ func TestClient_demoteMember(t *testing.T) {
 
 		node1 := s.configuration.ServerMembers[0]
 		_, err := s.DemoteMember(0, node1.Address, node1.ID, false)
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 		s.wg.Wait()
 	})
 
@@ -606,7 +606,7 @@ func TestClient_demoteMember(t *testing.T) {
 
 		node1 := s.configuration.ServerMembers[0]
 		_, err := s.DemoteMember(0, node1.Address, node1.ID, false)
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 		s.wg.Wait()
 	})
 }
@@ -633,7 +633,7 @@ func TestClient_removeMember(t *testing.T) {
 
 		node1 := s.configuration.ServerMembers[0]
 		_, err := s.RemoveMember(0, node1.Address, node1.ID, false)
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 		s.wg.Wait()
 	})
 
@@ -717,7 +717,7 @@ func TestClient_removeMember(t *testing.T) {
 
 		node1 := s.configuration.ServerMembers[0]
 		_, err := s.RemoveMember(0, node1.Address, node1.ID, false)
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 		s.wg.Wait()
 	})
 }
@@ -744,7 +744,7 @@ func TestClient_forceRemoveMember(t *testing.T) {
 
 		node1 := s.configuration.ServerMembers[0]
 		_, err := s.ForceRemoveMember(0, node1.Address, node1.ID, false)
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 		s.wg.Wait()
 	})
 
@@ -828,7 +828,7 @@ func TestClient_forceRemoveMember(t *testing.T) {
 
 		node1 := s.configuration.ServerMembers[0]
 		_, err := s.ForceRemoveMember(0, node1.Address, node1.ID, false)
-		assert.ErrorIs(err, ErrTimeoutSendingRequest)
+		assert.ErrorIs(err, ErrTimeout)
 		s.wg.Wait()
 	})
 }

--- a/errors.go
+++ b/errors.go
@@ -3,32 +3,84 @@ package rafty
 import "errors"
 
 var (
-	ErrAppendEntriesToLeader                 = errors.New("cannot send append entries to a leader")
-	ErrTermTooOld                            = errors.New("peer term older than mine")
-	ErrNoLeader                              = errors.New("no leader")
-	ErrNotLeader                             = errors.New("not leader")
-	ErrCommandNotFound                       = errors.New("commandNotFound")
-	ErrShutdown                              = errors.New("node is shutting down")
-	ErrLogNotFound                           = errors.New("log not found")
-	ErrLogMismatch                           = errors.New("log mismatch")
-	ErrLogNotUpToDateEnough                  = errors.New("log not up to date enough")
-	ErrIndexOutOfRange                       = errors.New("index out of range")
-	ErrUnkownRPCType                         = errors.New("unknown rpcType")
-	ErrTimeout                               = errors.New("operation timeout")
-	ErrUnkown                                = errors.New("unknown error")
-	ErrLeadershipTransferInProgress          = errors.New("leadership transfer in progress")
-	ErrMembershipChangeNodeTooSlow           = errors.New("new node is too slow catching up leader logs")
-	ErrMembershipChangeInProgress            = errors.New("membership change in progress")
-	ErrMembershipChangeNodeNotDemoted        = errors.New("node must be demoted before being removed")
+	// ErrAppendEntriesToLeader is triggered when trying to append entries to a leader
+	ErrAppendEntriesToLeader = errors.New("cannot send append entries to a leader")
+
+	// ErrTermTooOld is triggered when the term of the peer is older than mine
+	ErrTermTooOld = errors.New("peer term older than mine")
+
+	// ErrNoLeader is triggered when there is no existing leader
+	ErrNoLeader = errors.New("no leader")
+
+	// ErrNotLeader is triggered when trying to perform an operation on a non leader
+	ErrNotLeader = errors.New("not leader")
+
+	// ErrShutdown is triggered when the node is shutting down
+	ErrShutdown = errors.New("node is shutting down")
+
+	// ErrLogNotFound is triggered when the provided log is not found on the current node
+	ErrLogNotFound = errors.New("log not found")
+
+	// ErrIndexOutOfRange is triggered when trying to fetch an index that does not exist
+	ErrIndexOutOfRange = errors.New("index out of range")
+
+	// ErrUnkownRPCType is triggered when trying to perform an rpc call with wrong parameter
+	ErrUnkownRPCType = errors.New("unknown rpcType")
+
+	// ErrTimeout is triggered when an operation timed out
+	ErrTimeout = errors.New("operation timeout")
+
+	// ErrUnkown is triggered when trying to perform an operation that does not exist
+	ErrUnkown = errors.New("unknown error")
+
+	// ErrLeadershipTransferInProgress is triggered when a node receive an append entry request
+	// or a vote request
+	ErrLeadershipTransferInProgress = errors.New("leadership transfer in progress")
+
+	// ErrMembershipChangeNodeTooSlow is triggered by a timeout when a node is to slow to catch leader logs
+	ErrMembershipChangeNodeTooSlow = errors.New("new node is too slow catching up leader logs")
+
+	// ErrMembershipChangeInProgress is triggered by the leader when it already has a membership in progress
+	ErrMembershipChangeInProgress = errors.New("membership change in progress")
+
+	// ErrMembershipChangeNodeNotDemoted is triggered by the leader when remove a node without
+	// demoting it first
+	ErrMembershipChangeNodeNotDemoted = errors.New("node must be demoted before being removed")
+
+	// ErrMembershipChangeNodeDemotionForbidden is triggered by the leader when trying to demote a node can
+	// break cluster quorum
 	ErrMembershipChangeNodeDemotionForbidden = errors.New("node cannot be demoted, breaking cluster")
-	ErrClusterNotBootstrapped                = errors.New("cluster not bootstrapped")
-	ErrClusterAlreadyBootstrapped            = errors.New("cluster already bootstrapped")
-	ErrChecksumDataTooShort                  = errors.New("data to short for checksum")
-	ErrChecksumMistmatch                     = errors.New("CRC32 checksum mistmatch")
-	ErrKeyNotFound                           = errors.New("key not found")
-	ErrStoreClosed                           = errors.New("store closed")
-	ErrDataDirRequired                       = errors.New("data dir cannot be empty")
-	ErrNoSnapshotToTake                      = errors.New("no snapshot to take")
-	ErrLogCommandNotAllowed                  = errors.New("log command not allowed")
-	ErrClient                                = errors.New("fail to get grpc client")
+
+	// ErrClusterNotBootstrapped is triggered by the leader when the bootstrap options is set
+	// and a client is submitting a command
+	ErrClusterNotBootstrapped = errors.New("cluster not bootstrapped")
+
+	// ErrClusterAlreadyBootstrapped is triggered when trying to bootstrap the cluster again
+	ErrClusterAlreadyBootstrapped = errors.New("cluster already bootstrapped")
+
+	// ErrChecksumDataTooShort is triggered while decoding data with checksum
+	ErrChecksumDataTooShort = errors.New("data to short for checksum")
+
+	// ErrChecksumMistmatch is triggered while decoding data. It generally happen when
+	// a file is corrupted
+	ErrChecksumMistmatch = errors.New("CRC32 checksum mistmatch")
+
+	// ErrKeyNotFound is triggered when trying to fetch a key that does not exist
+	ErrKeyNotFound = errors.New("key not found")
+
+	// ErrStoreClosed is triggered when trying to perform an operation
+	// while the store is closed
+	ErrStoreClosed = errors.New("store closed")
+
+	// ErrDataDirRequired is triggered when data dir is missing
+	ErrDataDirRequired = errors.New("data dir cannot be empty")
+
+	// ErrNoSnapshotToTake is triggered when there is no snapshot to take
+	ErrNoSnapshotToTake = errors.New("no snapshot to take")
+
+	// ErrLogCommandNotAllowed is triggered when submitting a command that is not allowed
+	ErrLogCommandNotAllowed = errors.New("log command not allowed")
+
+	// ErrClient is triggered when failed to built grpc client
+	ErrClient = errors.New("fail to get grpc client")
 )

--- a/errors.go
+++ b/errors.go
@@ -14,7 +14,7 @@ var (
 	ErrLogNotUpToDateEnough                  = errors.New("log not up to date enough")
 	ErrIndexOutOfRange                       = errors.New("index out of range")
 	ErrUnkownRPCType                         = errors.New("unknown rpcType")
-	ErrTimeoutSendingRequest                 = errors.New("timeout sending request")
+	ErrTimeout                               = errors.New("operation timeout")
 	ErrUnkown                                = errors.New("unknown error")
 	ErrLeadershipTransferInProgress          = errors.New("leadership transfer in progress")
 	ErrMembershipChangeNodeTooSlow           = errors.New("new node is too slow catching up leader logs")

--- a/examples/grpc/single-server-cluster/main.go
+++ b/examples/grpc/single-server-cluster/main.go
@@ -52,8 +52,15 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	cacheOptions := rafty.LogCacheOptions{
+		Store:        store,
+		CacheOnWrite: true,
+		TTL:          2 * time.Second,
+	}
+	cacheStore := rafty.NewLogCache(cacheOptions)
+
 	fsm := NewSnapshotState(store)
-	s, err := rafty.NewRafty(addr, id, options, store, fsm, nil)
+	s, err := rafty.NewRafty(addr, id, options, cacheStore, fsm, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -68,7 +68,7 @@ func (r *Rafty) handleSendVoteRequest(data RPCRequest) {
 			Msgf("Vote granted to peer")
 
 		r.switchState(Follower, stepDown, true, request.CurrentTerm)
-		if err := r.logStore.storeMetadata(r.buildMetadata()); err != nil {
+		if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
 			panic(err)
 		}
 		response.CurrentTerm = request.CurrentTerm
@@ -133,7 +133,7 @@ func (r *Rafty) handleSendVoteRequest(data RPCRequest) {
 				Msgf("Vote granted to peer")
 
 			r.switchState(Follower, stepDown, false, request.CurrentTerm)
-			if err := r.logStore.storeMetadata(r.buildMetadata()); err != nil {
+			if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
 				panic(err)
 			}
 			data.ResponseChan <- rpcResponse
@@ -169,7 +169,7 @@ func (r *Rafty) handleSendVoteRequest(data RPCRequest) {
 		Msgf("Vote granted to peer")
 
 	r.switchState(Follower, stepDown, false, request.CurrentTerm)
-	if err := r.logStore.storeMetadata(r.buildMetadata()); err != nil {
+	if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -244,7 +244,7 @@ func (r *Rafty) handleSendAppendEntriesRequest(data RPCRequest) {
 	}
 
 	r.currentTerm.Store(request.Term)
-	if err := r.logStore.storeMetadata(r.buildMetadata()); err != nil {
+	if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -347,7 +347,7 @@ func (r *Rafty) handleSendAppendEntriesRequest(data RPCRequest) {
 						Msgf("Fail to apply config entry")
 				}
 			}
-			if err := r.logStore.storeMetadata(r.buildMetadata()); err != nil {
+			if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
 				panic(err)
 			}
 
@@ -387,7 +387,7 @@ func (r *Rafty) handleSendAppendEntriesRequest(data RPCRequest) {
 				Str("lastAppliedConfigTerm", fmt.Sprintf("%d", r.lastAppliedConfigTerm.Load())).
 				Msgf("Node state index updated")
 
-			if err := r.logStore.storeMetadata(r.buildMetadata()); err != nil {
+			if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
 				panic(err)
 			}
 		}

--- a/log_cache.go
+++ b/log_cache.go
@@ -22,6 +22,11 @@ func NewLogCache(options LogCacheOptions) *LogCache {
 	}
 }
 
+// Close will close the underlying long term store of the cache
+func (lc *LogCache) Close() error {
+	return lc.store.Close()
+}
+
 // isExpired return true if the cacheItem is expired
 func (i *cacheItem) isExpired() bool {
 	return !i.ttl.IsZero() && time.Now().Before(i.ttl)

--- a/log_cache.go
+++ b/log_cache.go
@@ -1,0 +1,274 @@
+package rafty
+
+import (
+	"fmt"
+	"time"
+)
+
+// NewLogCache allow us to configure the cache with the provided store option
+func NewLogCache(options LogCacheOptions) *LogCache {
+	var ttl time.Duration
+	if options.TTL == 0 {
+		ttl = 30 * time.Second
+	} else {
+		ttl = options.TTL
+	}
+
+	return &LogCache{
+		cache:        make(map[string]*cacheItem),
+		cacheOnWrite: options.CacheOnWrite,
+		store:        options.Store,
+		ttl:          ttl,
+	}
+}
+
+// isExpired return true if the cacheItem is expired
+func (i *cacheItem) isExpired() bool {
+	return !i.ttl.IsZero() && time.Now().Before(i.ttl)
+}
+
+// StoreLogs stores multiple log entries in cache but also
+// in long term storage
+func (lc *LogCache) StoreLogs(logs []*LogEntry) error {
+	if lc.cacheOnWrite {
+		lc.mu.Lock()
+		for _, entry := range logs {
+			lc.cache[fmt.Sprintf("%d", entry.Index)] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: entry}
+		}
+		lc.mu.Unlock()
+	}
+
+	return lc.store.StoreLogs(logs)
+}
+
+// StoreLogs stores multiple log entries
+func (lc *LogCache) StoreLog(log *LogEntry) error {
+	return lc.StoreLogs([]*LogEntry{log})
+}
+
+// GetLogByIndex return data from cache when exist otherwise
+// data is fetch from long term storage
+func (lc *LogCache) GetLogByIndex(index uint64) (*LogEntry, error) {
+	key := fmt.Sprintf("%d", index)
+
+	lc.mu.RLock()
+	if val, ok := lc.cache[key]; ok {
+		// if key is not expired
+		if !val.isExpired() {
+			lc.mu.RUnlock()
+			return val.data.(*LogEntry), nil
+		}
+	}
+	lc.mu.RUnlock()
+
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	delete(lc.cache, key)
+
+	data, err := lc.store.GetLogByIndex(index)
+	if err != nil {
+		return data, err
+	}
+
+	lc.cache[key] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: data}
+
+	return data, err
+}
+
+// GetLogsByRange return data from cache when exist otherwise
+// data is fetch from long term storage
+func (lc *LogCache) GetLogsByRange(minIndex, maxIndex, maxAppendEntries uint64) (response GetLogsByRangeResponse) {
+	key := fmt.Sprintf("%d%d%d", minIndex, maxIndex, maxAppendEntries)
+
+	lc.mu.RLock()
+	if val, ok := lc.cache[key]; ok {
+		// if key is not expired
+		if !val.isExpired() {
+			lc.mu.RUnlock()
+			return val.data.(GetLogsByRangeResponse)
+		}
+	}
+	lc.mu.RUnlock()
+
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	delete(lc.cache, key)
+
+	data := lc.store.GetLogsByRange(minIndex, maxIndex, maxAppendEntries)
+	if data.Err == nil {
+		lc.cache[key] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: data}
+	}
+
+	return data
+}
+
+// GetLastConfiguration return data from cache when exist otherwise
+// data is fetch from long term storage
+func (lc *LogCache) GetLastConfiguration(key string) (*LogEntry, error) {
+	lc.mu.RLock()
+	if val, ok := lc.cache[key]; ok {
+		// if key is not expired
+		if !val.isExpired() {
+			lc.mu.RUnlock()
+			return val.data.(*LogEntry), nil
+		}
+	}
+	lc.mu.RUnlock()
+
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	delete(lc.cache, key)
+
+	data, err := lc.store.GetLastConfiguration()
+	if err != nil {
+		return data, err
+	}
+
+	lc.cache[key] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: data}
+
+	return data, err
+}
+
+// DiscardLogs remove key cache and from long term storage
+func (lc *LogCache) DiscardLogs(minIndex, maxIndex uint64) error {
+	lc.mu.Lock()
+	for index := minIndex; index <= maxIndex; index++ {
+		delete(lc.cache, fmt.Sprintf("%d", index))
+	}
+	lc.mu.Unlock()
+
+	return lc.store.DiscardLogs(minIndex, maxIndex)
+}
+
+// GetMetadata return data from cache when exist otherwise
+// data is fetch from long term storage
+func (lc *LogCache) GetMetadata(key string) ([]byte, error) {
+	lc.mu.RLock()
+	if val, ok := lc.cache[key]; ok {
+		// if key is not expired
+		if !val.isExpired() {
+			lc.mu.RUnlock()
+			return val.data.([]byte), nil
+		}
+	}
+	lc.mu.RUnlock()
+
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	delete(lc.cache, key)
+
+	data, err := lc.store.GetMetadata()
+	if err != nil {
+		return data, err
+	}
+
+	lc.cache[key] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: data}
+
+	return data, err
+}
+
+// storeMetadata stores data in cache and in long term storage
+func (lc *LogCache) storeMetadata(key string, value []byte) error {
+	lc.mu.Lock()
+	if lc.cacheOnWrite {
+		lc.cache[key] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: value}
+	}
+	lc.mu.Unlock()
+
+	return lc.store.storeMetadata(value)
+}
+
+// Set stores data in cache and in long term storage
+func (lc *LogCache) Set(key, value []byte) error {
+	lc.mu.Lock()
+	if lc.cacheOnWrite {
+		lc.cache[string(key)] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: value}
+	}
+	lc.mu.Unlock()
+
+	return lc.store.Set(key, value)
+}
+
+// Get return data from cache when exist otherwise
+// data is fetch from long term storage
+func (lc *LogCache) Get(key []byte) ([]byte, error) {
+	lc.mu.RLock()
+	s := string(key)
+	if val, ok := lc.cache[s]; ok {
+		// if key is not expired
+		if !val.isExpired() {
+			lc.mu.RUnlock()
+			return val.data.([]byte), nil
+		}
+	}
+	lc.mu.RUnlock()
+
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	delete(lc.cache, s)
+
+	data, err := lc.store.Get(key)
+	if err != nil {
+		return data, err
+	}
+
+	if lc.cacheOnWrite {
+		lc.cache[s] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: data}
+	}
+
+	return data, err
+}
+
+// FirstIndex return data from cache when exist otherwise
+// data is fetch from long term storage
+func (lc *LogCache) FirstIndex(key string) (uint64, error) {
+	lc.mu.RLock()
+	if val, ok := lc.cache[key]; ok {
+		// if key is not expired
+		if !val.isExpired() {
+			lc.mu.RUnlock()
+			return val.data.(uint64), nil
+		}
+	}
+	lc.mu.RUnlock()
+
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	delete(lc.cache, key)
+
+	data, err := lc.store.FirstIndex()
+	if err != nil {
+		return data, err
+	}
+
+	lc.cache[key] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: data}
+
+	return data, err
+}
+
+// LastIndex return data from cache when exist otherwise
+// data is fetch from long term storage
+func (lc *LogCache) LastIndex(key string) (uint64, error) {
+	lc.mu.RLock()
+	if val, ok := lc.cache[key]; ok {
+		// if key is not expired
+		if !val.isExpired() {
+			lc.mu.RUnlock()
+			return val.data.(uint64), nil
+		}
+	}
+	lc.mu.RUnlock()
+
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	delete(lc.cache, key)
+
+	data, err := lc.store.LastIndex()
+	if err != nil {
+		return data, err
+	}
+
+	lc.cache[key] = &cacheItem{ttl: time.Now().Add(lc.ttl), data: data}
+
+	return data, err
+}

--- a/log_cache.go
+++ b/log_cache.go
@@ -175,7 +175,7 @@ func (lc *LogCache) storeMetadata(key string, value []byte) error {
 	}
 	lc.mu.Unlock()
 
-	return lc.store.storeMetadata(value)
+	return lc.store.StoreMetadata(value)
 }
 
 // Set stores data in cache and in long term storage

--- a/log_cache_test.go
+++ b/log_cache_test.go
@@ -25,10 +25,6 @@ func TestLogCache(t *testing.T) {
 		}()
 		store, err := NewBoltStorage(boltOptions)
 		assert.Nil(err)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(store.Close())
-		}()
 
 		cacheOptions := LogCacheOptions{
 			Store:        store,
@@ -36,6 +32,10 @@ func TestLogCache(t *testing.T) {
 			TTL:          2 * time.Second,
 		}
 		cacheStore := NewLogCache(cacheOptions)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(cacheStore.Close())
+		}()
 
 		var logs []*LogEntry
 		for index := range 100 {
@@ -50,7 +50,6 @@ func TestLogCache(t *testing.T) {
 	})
 
 	t.Run("cahce_get_log_by_index", func(t *testing.T) {
-
 		boltOptions := BoltOptions{
 			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cahce_get_log_by_index"),
 			Options: bbolt.DefaultOptions,
@@ -61,10 +60,6 @@ func TestLogCache(t *testing.T) {
 		}()
 		store, err := NewBoltStorage(boltOptions)
 		assert.Nil(err)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(store.Close())
-		}()
 
 		cacheOptions := LogCacheOptions{
 			Store:        store,
@@ -72,6 +67,10 @@ func TestLogCache(t *testing.T) {
 			TTL:          2 * time.Second,
 		}
 		cacheStore := NewLogCache(cacheOptions)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(cacheStore.Close())
+		}()
 
 		var logs []*LogEntry
 		for index := range 100 {
@@ -98,7 +97,6 @@ func TestLogCache(t *testing.T) {
 	})
 
 	t.Run("cache_get_logs_by_range", func(t *testing.T) {
-
 		boltOptions := BoltOptions{
 			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_get_logs_by_range"),
 			Options: bbolt.DefaultOptions,
@@ -109,10 +107,6 @@ func TestLogCache(t *testing.T) {
 		}()
 		store, err := NewBoltStorage(boltOptions)
 		assert.Nil(err)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(store.Close())
-		}()
 
 		cacheOptions := LogCacheOptions{
 			Store:        store,
@@ -120,6 +114,10 @@ func TestLogCache(t *testing.T) {
 			TTL:          2 * time.Second,
 		}
 		cacheStore := NewLogCache(cacheOptions)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(cacheStore.Close())
+		}()
 
 		var logs []*LogEntry
 		for index := range 100 {
@@ -141,7 +139,6 @@ func TestLogCache(t *testing.T) {
 	})
 
 	t.Run("cache_get_last_configuration", func(t *testing.T) {
-
 		boltOptions := BoltOptions{
 			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_get_last_configuration"),
 			Options: bbolt.DefaultOptions,
@@ -152,10 +149,6 @@ func TestLogCache(t *testing.T) {
 		}()
 		store, err := NewBoltStorage(boltOptions)
 		assert.Nil(err)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(store.Close())
-		}()
 
 		cacheOptions := LogCacheOptions{
 			Store:        store,
@@ -163,6 +156,10 @@ func TestLogCache(t *testing.T) {
 			TTL:          2 * time.Second,
 		}
 		cacheStore := NewLogCache(cacheOptions)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(cacheStore.Close())
+		}()
 
 		_, err = cacheStore.GetLastConfiguration("GetLastConfiguration")
 		assert.Error(err)
@@ -186,7 +183,6 @@ func TestLogCache(t *testing.T) {
 	})
 
 	t.Run("cache_discard_logs", func(t *testing.T) {
-
 		boltOptions := BoltOptions{
 			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_discard_logs"),
 			Options: bbolt.DefaultOptions,
@@ -197,22 +193,21 @@ func TestLogCache(t *testing.T) {
 		}()
 		store, err := NewBoltStorage(boltOptions)
 		assert.Nil(err)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(store.Close())
-		}()
 
 		cacheOptions := LogCacheOptions{
 			Store:        store,
 			CacheOnWrite: true,
 		}
 		cacheStore := NewLogCache(cacheOptions)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(cacheStore.Close())
+		}()
 
 		assert.Nil(cacheStore.DiscardLogs(0, 100))
 	})
 
 	t.Run("cache_metadata", func(t *testing.T) {
-
 		boltOptions := BoltOptions{
 			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_metadata"),
 			Options: bbolt.DefaultOptions,
@@ -258,7 +253,6 @@ func TestLogCache(t *testing.T) {
 	})
 
 	t.Run("cache_set_get", func(t *testing.T) {
-
 		boltOptions := BoltOptions{
 			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_set_get"),
 			Options: bbolt.DefaultOptions,
@@ -315,10 +309,6 @@ func TestLogCache(t *testing.T) {
 		}()
 		store, err := NewBoltStorage(boltOptions)
 		assert.Nil(err)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(store.Close())
-		}()
 
 		cacheOptions := LogCacheOptions{
 			Store:        store,
@@ -326,6 +316,10 @@ func TestLogCache(t *testing.T) {
 			TTL:          2 * time.Second,
 		}
 		cacheStore := NewLogCache(cacheOptions)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(cacheStore.Close())
+		}()
 
 		var logs []*LogEntry
 		for index := range 10 {

--- a/log_cache_test.go
+++ b/log_cache_test.go
@@ -1,0 +1,369 @@
+package rafty
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.etcd.io/bbolt"
+)
+
+func TestLogCache(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("cache_store_logs", func(t *testing.T) {
+		boltOptions := BoltOptions{
+			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_store_logs"),
+			Options: bbolt.DefaultOptions,
+		}
+
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+		}()
+		store, err := NewBoltStorage(boltOptions)
+		assert.Nil(err)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(store.Close())
+		}()
+
+		cacheOptions := LogCacheOptions{
+			Store:        store,
+			CacheOnWrite: true,
+			TTL:          2 * time.Second,
+		}
+		cacheStore := NewLogCache(cacheOptions)
+
+		var logs []*LogEntry
+		for index := range 100 {
+			logs = append(logs, &LogEntry{
+				Index: uint64(index),
+				Term:  1,
+			})
+		}
+
+		assert.Nil(cacheStore.StoreLogs(logs))
+		assert.Nil(cacheStore.StoreLog(&LogEntry{Index: 100, Term: 1}))
+	})
+
+	t.Run("cahce_get_log_by_index", func(t *testing.T) {
+
+		boltOptions := BoltOptions{
+			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cahce_get_log_by_index"),
+			Options: bbolt.DefaultOptions,
+		}
+
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+		}()
+		store, err := NewBoltStorage(boltOptions)
+		assert.Nil(err)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(store.Close())
+		}()
+
+		cacheOptions := LogCacheOptions{
+			Store:        store,
+			CacheOnWrite: true,
+			TTL:          2 * time.Second,
+		}
+		cacheStore := NewLogCache(cacheOptions)
+
+		var logs []*LogEntry
+		for index := range 100 {
+			logs = append(logs, &LogEntry{
+				Index: uint64(index),
+				Term:  1,
+			})
+		}
+
+		assert.Nil(cacheStore.StoreLogs(logs))
+
+		index := uint64(100)
+		_, err = cacheStore.GetLogByIndex(index)
+		assert.Error(err)
+		assert.Nil(cacheStore.StoreLog(&LogEntry{Index: index, Term: 1}))
+		result, err := cacheStore.GetLogByIndex(index)
+		assert.Nil(err)
+		assert.Equal(index, result.Index)
+
+		time.Sleep(2 * time.Second)
+		result, err = cacheStore.GetLogByIndex(index)
+		assert.Nil(err)
+		assert.Equal(index, result.Index)
+	})
+
+	t.Run("cache_get_logs_by_range", func(t *testing.T) {
+
+		boltOptions := BoltOptions{
+			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_get_logs_by_range"),
+			Options: bbolt.DefaultOptions,
+		}
+
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+		}()
+		store, err := NewBoltStorage(boltOptions)
+		assert.Nil(err)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(store.Close())
+		}()
+
+		cacheOptions := LogCacheOptions{
+			Store:        store,
+			CacheOnWrite: true,
+			TTL:          2 * time.Second,
+		}
+		cacheStore := NewLogCache(cacheOptions)
+
+		var logs []*LogEntry
+		for index := range 100 {
+			logs = append(logs, &LogEntry{
+				Index: uint64(index),
+				Term:  1,
+			})
+		}
+
+		assert.Nil(cacheStore.StoreLogs(logs))
+		min, max, maxAppendEntries := uint64(0), uint64(50), uint64(10)
+		response := cacheStore.GetLogsByRange(min, max, maxAppendEntries)
+		assert.Nil(response.Err)
+
+		time.Sleep(2 * time.Second)
+		response = cacheStore.GetLogsByRange(min, max, maxAppendEntries)
+		assert.Greater(response.Total, maxAppendEntries)
+		assert.Equal(true, response.SendSnapshot)
+	})
+
+	t.Run("cache_get_last_configuration", func(t *testing.T) {
+
+		boltOptions := BoltOptions{
+			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_get_last_configuration"),
+			Options: bbolt.DefaultOptions,
+		}
+
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+		}()
+		store, err := NewBoltStorage(boltOptions)
+		assert.Nil(err)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(store.Close())
+		}()
+
+		cacheOptions := LogCacheOptions{
+			Store:        store,
+			CacheOnWrite: true,
+			TTL:          2 * time.Second,
+		}
+		cacheStore := NewLogCache(cacheOptions)
+
+		_, err = cacheStore.GetLastConfiguration("GetLastConfiguration")
+		assert.Error(err)
+
+		enc := EncodePeers([]Peer{{Address: "127.0.0.1:60000", ID: "60"}, {Address: "127.0.0.1:61000", ID: "61"}, {Address: "127.0.0.1:62000", ID: "62"}})
+		configIndex := uint64(50)
+		log := &LogEntry{
+			LogType: uint32(LogConfiguration),
+			Index:   configIndex,
+			Term:    1,
+			Command: enc,
+		}
+
+		assert.Nil(cacheStore.StoreLog(log))
+		_, err = cacheStore.GetLastConfiguration("GetLastConfiguration")
+		assert.Nil(err)
+
+		time.Sleep(2 * time.Second)
+		_, err = cacheStore.GetLastConfiguration("GetLastConfiguration")
+		assert.Nil(err)
+	})
+
+	t.Run("cache_discard_logs", func(t *testing.T) {
+
+		boltOptions := BoltOptions{
+			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_discard_logs"),
+			Options: bbolt.DefaultOptions,
+		}
+
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+		}()
+		store, err := NewBoltStorage(boltOptions)
+		assert.Nil(err)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(store.Close())
+		}()
+
+		cacheOptions := LogCacheOptions{
+			Store:        store,
+			CacheOnWrite: true,
+		}
+		cacheStore := NewLogCache(cacheOptions)
+
+		assert.Nil(cacheStore.DiscardLogs(0, 100))
+	})
+
+	t.Run("cache_metadata", func(t *testing.T) {
+
+		boltOptions := BoltOptions{
+			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_metadata"),
+			Options: bbolt.DefaultOptions,
+		}
+
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+		}()
+		store, err := NewBoltStorage(boltOptions)
+		assert.Nil(err)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(store.Close())
+		}()
+
+		cacheOptions := LogCacheOptions{
+			Store:        store,
+			CacheOnWrite: true,
+			TTL:          2 * time.Second,
+		}
+		cacheStore := NewLogCache(cacheOptions)
+
+		s := basicNodeSetup()
+		defer func() {
+			assert.Nil(s.logStore.Close())
+			assert.Nil(os.RemoveAll(getRootDir(s.options.DataDir)))
+		}()
+		s.currentTerm.Store(1)
+		s.lastApplied.Store(1)
+
+		_, err = cacheStore.GetMetadata("metadata")
+		assert.Error(err)
+
+		assert.Nil(cacheStore.storeMetadata("metadata", s.buildMetadata()))
+
+		time.Sleep(time.Second)
+		_, err = cacheStore.GetMetadata("metadata")
+		assert.Nil(err)
+
+		time.Sleep(2 * time.Second)
+		_, err = cacheStore.GetMetadata("metadata")
+		assert.Nil(err)
+	})
+
+	t.Run("cache_set_get", func(t *testing.T) {
+
+		boltOptions := BoltOptions{
+			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_set_get"),
+			Options: bbolt.DefaultOptions,
+		}
+
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+		}()
+		store, err := NewBoltStorage(boltOptions)
+		assert.Nil(err)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(store.Close())
+		}()
+
+		cacheOptions := LogCacheOptions{
+			Store:        store,
+			CacheOnWrite: true,
+			TTL:          2 * time.Second,
+		}
+		cacheStore := NewLogCache(cacheOptions)
+
+		s := basicNodeSetup()
+		defer func() {
+			assert.Nil(s.logStore.Close())
+			assert.Nil(os.RemoveAll(getRootDir(s.options.DataDir)))
+		}()
+		s.currentTerm.Store(1)
+		s.lastApplied.Store(1)
+
+		key, value := []byte("key"), []byte("value")
+		_, err = cacheStore.Get(key)
+		assert.Error(err)
+
+		assert.Nil(cacheStore.Set(key, value))
+
+		time.Sleep(1 * time.Second)
+		_, err = cacheStore.Get(key)
+		assert.Nil(err)
+
+		time.Sleep(2 * time.Second)
+		_, err = cacheStore.Get(key)
+		assert.Nil(err)
+	})
+
+	t.Run("cache_first_index_last_index", func(t *testing.T) {
+		boltOptions := BoltOptions{
+			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_first_index_last_index"),
+			Options: bbolt.DefaultOptions,
+		}
+
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+		}()
+		store, err := NewBoltStorage(boltOptions)
+		assert.Nil(err)
+		defer func() {
+			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
+			assert.Nil(store.Close())
+		}()
+
+		cacheOptions := LogCacheOptions{
+			Store:        store,
+			CacheOnWrite: true,
+			TTL:          2 * time.Second,
+		}
+		cacheStore := NewLogCache(cacheOptions)
+
+		var logs []*LogEntry
+		for index := range 10 {
+			logs = append(logs, &LogEntry{
+				Index: uint64(index),
+				Term:  1,
+			})
+		}
+
+		first, last := uint64(0), uint64(9)
+		_, err = cacheStore.FirstIndex(fmt.Sprintf("%d", first))
+		assert.Error(err)
+		_, err = cacheStore.LastIndex(fmt.Sprintf("%d", last))
+		assert.Error(err)
+
+		assert.Nil(cacheStore.StoreLogs(logs))
+
+		f, err := cacheStore.FirstIndex(fmt.Sprintf("%d", first))
+		assert.Nil(err)
+		assert.Equal(first, f)
+		l, err := cacheStore.LastIndex(fmt.Sprintf("%d", last))
+		assert.Nil(err)
+		assert.Equal(last, l)
+
+		time.Sleep(time.Second)
+		f, err = cacheStore.FirstIndex(fmt.Sprintf("%d", first))
+		assert.Nil(err)
+		assert.Equal(first, f)
+		l, err = cacheStore.LastIndex(fmt.Sprintf("%d", last))
+		assert.Nil(err)
+		assert.Equal(last, l)
+
+		time.Sleep(2 * time.Second)
+		f, err = cacheStore.FirstIndex(fmt.Sprintf("%d", first))
+		assert.Nil(err)
+		assert.Equal(first, f)
+		l, err = cacheStore.LastIndex(fmt.Sprintf("%d", last))
+		assert.Nil(err)
+		assert.Equal(last, l)
+	})
+}

--- a/log_cache_types.go
+++ b/log_cache_types.go
@@ -1,0 +1,50 @@
+package rafty
+
+import (
+	"sync"
+	"time"
+)
+
+// cacheItem holds the data with its associated ttl
+type cacheItem struct {
+	// ttl is the maximum amount of time to keep the entry in cache
+	ttl time.Time
+
+	// data is the data to put in cache
+	data any
+}
+
+// LogCacheOptions hold all cache options that will be later
+// used by LogCache
+type LogCacheOptions struct {
+	// Store hold the long term storage data
+	Store Store
+
+	// CacheOnWrite when set to true will put every write
+	// request in cache before writting to the long term storage
+	CacheOnWrite bool
+
+	// TTL is the maximum amount of time to keep the entry in cache.
+	// Default to 30 seconds if ttl == 0
+	TTL time.Duration
+}
+
+// LogCache hold the requirements related to caching rafty data
+type LogCache struct {
+	// mu hold locking mecanism
+	mu sync.RWMutex
+
+	// cache hold the log entry
+	cache map[string]*cacheItem
+
+	// cacheOnWrite when set to true will put every write
+	// request in cache before writting to the long term storage
+	cacheOnWrite bool
+
+	// store hold the long term storage data
+	store Store
+
+	// ttl is the maximum amount of time to keep the entry in cache.
+	// Default to 30 seconds if ttl == 0
+	ttl time.Duration
+}

--- a/logs_persistant.go
+++ b/logs_persistant.go
@@ -217,8 +217,8 @@ func (b *BoltStore) GetMetadata() ([]byte, error) {
 	return b.getKV(bucketMetadataName, []byte("metadata"))
 }
 
-// storeMetadata will store rafty metadata into the k/v bucket
-func (b *BoltStore) storeMetadata(value []byte) error {
+// StoreMetadata will store rafty metadata into the k/v bucket
+func (b *BoltStore) StoreMetadata(value []byte) error {
 	return b.storeKV(bucketMetadataName, []byte("metadata"), value)
 }
 

--- a/logs_persistant.go
+++ b/logs_persistant.go
@@ -8,6 +8,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
+// NewBoltStorage allow us to configure bolt storage with the provided options
 func NewBoltStorage(options BoltOptions) (*BoltStore, error) {
 	var (
 		db  *bolt.DB

--- a/logs_persistant_test.go
+++ b/logs_persistant_test.go
@@ -239,7 +239,7 @@ func TestLogsPersistant(t *testing.T) {
 		s.currentTerm.Store(1)
 		s.lastApplied.Store(1)
 
-		assert.Nil(store.storeMetadata(s.buildMetadata()))
+		assert.Nil(store.StoreMetadata(s.buildMetadata()))
 		_, err = store.GetMetadata()
 		assert.Nil(err)
 		assert.Nil(store.Close())

--- a/logs_persistant_test.go
+++ b/logs_persistant_test.go
@@ -232,6 +232,10 @@ func TestLogsPersistant(t *testing.T) {
 		assert.Error(err)
 
 		s := basicNodeSetup()
+		defer func() {
+			assert.Nil(s.logStore.Close())
+			assert.Nil(os.RemoveAll(getRootDir(s.options.DataDir)))
+		}()
 		s.currentTerm.Store(1)
 		s.lastApplied.Store(1)
 

--- a/logs_persistant_types.go
+++ b/logs_persistant_types.go
@@ -68,9 +68,9 @@ type Store interface {
 	// GetMetadata will fetch rafty metadata from the k/v store
 	GetMetadata() ([]byte, error)
 
-	// storeMetadata will store rafty metadata into the k/v bucket.
+	// StoreMetadata will store rafty metadata into the k/v bucket.
 	// This won't be replicated
-	storeMetadata([]byte) error
+	StoreMetadata([]byte) error
 
 	// Set will add key/value to the k/v store
 	Set(key, value []byte) error

--- a/membership.go
+++ b/membership.go
@@ -141,7 +141,7 @@ func (r *leader) addNode(member Peer, req *raftypb.MembershipChangeRequest, foll
 
 	if !r.rafty.isPartOfTheCluster(member) {
 		_ = r.rafty.applyConfigEntry(entries[0])
-		if err := r.rafty.logStore.storeMetadata(r.rafty.buildMetadata()); err != nil {
+		if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 			panic(err)
 		}
 
@@ -257,7 +257,7 @@ func (r *leader) promoteNode(action MembershipChange, member Peer, follower *fol
 	}
 
 	_ = r.rafty.applyConfigEntry(entries[0])
-	if err := r.rafty.logStore.storeMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -318,7 +318,7 @@ func (r *leader) demoteNode(action MembershipChange, member Peer) (success bool,
 	}
 
 	_ = r.rafty.applyConfigEntry(entries[0])
-	if err := r.rafty.logStore.storeMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -399,7 +399,7 @@ func (r *leader) removeNode(action MembershipChange, member Peer) (success bool,
 	}
 
 	_ = r.rafty.applyConfigEntry(entries[0])
-	if err := r.rafty.logStore.storeMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 

--- a/rafty.go
+++ b/rafty.go
@@ -232,7 +232,7 @@ func (r *Rafty) Start() error {
 	if r.id == "" {
 		r.id = uuid.NewString()
 		r.connectionManager.id = r.id
-		if err := r.logStore.storeMetadata(r.buildMetadata()); err != nil {
+		if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
 			return fmt.Errorf("fail to persist metadata %w", err)
 		}
 	}

--- a/rafty_test.go
+++ b/rafty_test.go
@@ -153,7 +153,7 @@ func TestRafty_newRafty(t *testing.T) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		assert.Nil(store.storeMetadata([]byte("a=b")))
+		assert.Nil(store.StoreMetadata([]byte("a=b")))
 		assert.Nil(store.Close())
 		defer func() {
 			if r := recover(); r != nil {
@@ -210,7 +210,7 @@ func TestRafty_restore(t *testing.T) {
 		s.updateEntriesIndex(protoEntries)
 		assert.Nil(s.logStore.StoreLogs(entries))
 		assert.Nil(s.applyConfigEntry(entry))
-		assert.Nil(s.logStore.storeMetadata(s.buildMetadata()))
+		assert.Nil(s.logStore.StoreMetadata(s.buildMetadata()))
 		metadata, err := s.logStore.GetMetadata()
 		assert.Nil(err)
 		s.isBootstrapped.Store(false)
@@ -225,7 +225,7 @@ func TestRafty_restore(t *testing.T) {
 			assert.Nil(os.RemoveAll(getRootDir(s.options.DataDir)))
 		}()
 
-		assert.Nil(s.logStore.storeMetadata([]byte("a=b")))
+		assert.Nil(s.logStore.StoreMetadata([]byte("a=b")))
 		metadata, err := s.logStore.GetMetadata()
 		assert.Nil(err)
 		s.isBootstrapped.Store(false)
@@ -239,7 +239,7 @@ func TestRafty_restore(t *testing.T) {
 		}()
 		s.fillIDs()
 		s.isBootstrapped.Store(false)
-		assert.Nil(s.logStore.storeMetadata([]byte("a=b")))
+		assert.Nil(s.logStore.StoreMetadata([]byte("a=b")))
 		assert.Nil(s.logStore.Close())
 		options := s.options
 

--- a/raftypb.go
+++ b/raftypb.go
@@ -102,7 +102,7 @@ func (r *rpcManager) SendPreVoteRequest(ctx context.Context, in *raftypb.PreVote
 		return nil, ErrShutdown
 
 	case <-time.After(500 * time.Millisecond):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 
 	select {
@@ -116,7 +116,7 @@ func (r *rpcManager) SendPreVoteRequest(ctx context.Context, in *raftypb.PreVote
 		return nil, ErrShutdown
 
 	case <-time.After(time.Second):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }
 
@@ -142,7 +142,7 @@ func (r *rpcManager) SendVoteRequest(ctx context.Context, in *raftypb.VoteReques
 		return nil, ErrShutdown
 
 	case <-time.After(500 * time.Millisecond):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 
 	select {
@@ -156,7 +156,7 @@ func (r *rpcManager) SendVoteRequest(ctx context.Context, in *raftypb.VoteReques
 		return nil, ErrShutdown
 
 	case <-time.After(time.Second):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }
 
@@ -182,7 +182,7 @@ func (r *rpcManager) SendAppendEntriesRequest(ctx context.Context, in *raftypb.A
 		return nil, ErrShutdown
 
 	case <-time.After(500 * time.Millisecond):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 
 	select {
@@ -196,7 +196,7 @@ func (r *rpcManager) SendAppendEntriesRequest(ctx context.Context, in *raftypb.A
 		return nil, ErrShutdown
 
 	case <-time.After(time.Second):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }
 
@@ -260,7 +260,7 @@ func (r *rpcManager) ForwardCommandToLeader(ctx context.Context, in *raftypb.For
 		return nil, ErrShutdown
 
 	case <-time.After(500 * time.Millisecond):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 
 	select {
@@ -274,7 +274,7 @@ func (r *rpcManager) ForwardCommandToLeader(ctx context.Context, in *raftypb.For
 		return nil, ErrShutdown
 
 	case <-time.After(time.Second):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }
 
@@ -318,7 +318,7 @@ func (r *rpcManager) SendMembershipChangeRequest(ctx context.Context, in *raftyp
 		return nil, ErrShutdown
 
 	case <-time.After(500 * time.Millisecond):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 
 	select {
@@ -332,7 +332,7 @@ func (r *rpcManager) SendMembershipChangeRequest(ctx context.Context, in *raftyp
 		return nil, ErrShutdown
 
 	case <-time.After(membershipTimeoutSeconds * time.Second):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }
 
@@ -357,7 +357,7 @@ func (r *rpcManager) SendBootstrapClusterRequest(ctx context.Context, in *raftyp
 		return nil, ErrShutdown
 
 	case <-time.After(500 * time.Millisecond):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 
 	select {
@@ -371,7 +371,7 @@ func (r *rpcManager) SendBootstrapClusterRequest(ctx context.Context, in *raftyp
 		return nil, ErrShutdown
 
 	case <-time.After(time.Second):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }
 
@@ -396,7 +396,7 @@ func (r *rpcManager) SendInstallSnapshotRequest(ctx context.Context, in *raftypb
 		return nil, ErrShutdown
 
 	case <-time.After(500 * time.Millisecond):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 
 	select {
@@ -410,6 +410,6 @@ func (r *rpcManager) SendInstallSnapshotRequest(ctx context.Context, in *raftypb
 		return nil, ErrShutdown
 
 	case <-time.After(5 * time.Second):
-		return nil, ErrTimeoutSendingRequest
+		return nil, ErrTimeout
 	}
 }

--- a/rpcs.go
+++ b/rpcs.go
@@ -541,7 +541,7 @@ func (r *Rafty) bootstrapCluster(data RPCRequest) {
 		panic(err)
 	}
 	_ = r.applyConfigEntry(entries[0])
-	if err := r.logStore.storeMetadata(r.buildMetadata()); err != nil {
+	if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
 		panic(err)
 	}
 

--- a/rpcs_test.go
+++ b/rpcs_test.go
@@ -57,7 +57,7 @@ func TestRpcs_askNodeIDResult(t *testing.T) {
 	resp := RPCResponse{
 		TargetPeer: Peer{Address: s.configuration.ServerMembers[0].Address},
 		Response:   rpcResponse,
-		Error:      ErrTimeoutSendingRequest,
+		Error:      ErrTimeout,
 	}
 
 	t.Run("error", func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestRpcs_getLeaderResult(t *testing.T) {
 	resp := RPCResponse{
 		TargetPeer: Peer{Address: s.configuration.ServerMembers[0].Address},
 		Response:   rpcResponse,
-		Error:      ErrTimeoutSendingRequest,
+		Error:      ErrTimeout,
 	}
 
 	t.Run("error", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestRpcs_membershipChangeResponse(t *testing.T) {
 	resp := RPCResponse{
 		TargetPeer: Peer{Address: s.configuration.ServerMembers[0].Address},
 		Response:   rpcResponse,
-		Error:      ErrTimeoutSendingRequest,
+		Error:      ErrTimeout,
 	}
 
 	t.Run("error", func(t *testing.T) {

--- a/state_candidate.go
+++ b/state_candidate.go
@@ -121,7 +121,7 @@ func (r *candidate) handlePreVoteResponse(resp RPCResponse) {
 	if response.CurrentTerm > response.RequesterTerm {
 		r.rafty.currentTerm.Store(response.CurrentTerm)
 		r.rafty.switchState(Follower, stepDown, false, response.CurrentTerm)
-		if err := r.rafty.logStore.storeMetadata(r.rafty.buildMetadata()); err != nil {
+		if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 			panic(err)
 		}
 		return
@@ -149,7 +149,7 @@ func (r *candidate) handlePreVoteResponse(resp RPCResponse) {
 // to other nodes in order to elect a leader
 func (r *candidate) startElection() {
 	currentTerm := r.rafty.currentTerm.Add(1)
-	if err := r.rafty.logStore.storeMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -226,7 +226,7 @@ func (r *candidate) handleVoteResponse(resp RPCResponse) {
 
 		r.rafty.currentTerm.Store(response.CurrentTerm)
 		r.rafty.switchState(Follower, stepDown, false, response.CurrentTerm)
-		if err := r.rafty.logStore.storeMetadata(r.rafty.buildMetadata()); err != nil {
+		if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 			panic(err)
 		}
 		return
@@ -254,7 +254,7 @@ func (r *candidate) handleVoteResponse(resp RPCResponse) {
 func (r *candidate) isSingleServerCluster() {
 	currentTerm := r.rafty.currentTerm.Add(1)
 	r.rafty.switchState(Candidate, stepUp, true, currentTerm)
-	if err := r.rafty.logStore.storeMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 	r.rafty.switchState(Leader, stepUp, true, currentTerm)


### PR DESCRIPTION
Implement https://github.com/Lord-Y/rafty/issues/36

This implementation sets the same TTL for all keys.
The other implementation problem is when is no cleanup routine that auto remove expired entries.
This as not been implemented because there is no way to use a context to stop the routine while the node is shutting down.
This implementation can be done on user side.