### PR TITLE
Separate logStore and clusterStore

### DIFF
--- a/examples/grpc/cluster-3-nodes/main.go
+++ b/examples/grpc/cluster-3-nodes/main.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/Lord-Y/rafty"
@@ -101,7 +102,7 @@ func main() {
 	}
 	store, _ := rafty.NewBoltStorage(storeOptions)
 	fsm := NewSnapshotState(store)
-	s, _ := rafty.NewRafty(addr, id, options, store, fsm, nil)
+	s, _ := rafty.NewRafty(addr, id, options, store, store, fsm, nil)
 
 	if *submitCommands {
 		go func() {
@@ -143,7 +144,7 @@ func main() {
 					var err error
 					store, _ := rafty.NewBoltStorage(storeOptions)
 					fsm := NewSnapshotState(store)
-					if s, err = rafty.NewRafty(addr, id, options, store, fsm, nil); err != nil {
+					if s, err = rafty.NewRafty(addr, id, options, store, store, fsm, nil); err != nil {
 						s.Logger.Fatal().Err(err).Msg("Fail to create cluster config")
 					}
 					if err := s.Start(); err != nil {
@@ -166,12 +167,30 @@ func main() {
 	}
 }
 
+// userLogInMemory hold the requirements related to user data
+type userLogInMemory struct {
+	// mu hold locking mecanism
+	mu sync.RWMutex
+
+	// userStore map holds a map of the log entries
+	userStore map[uint64]*rafty.LogEntry
+
+	// metadata map holds the a map of metadata store
+	metadata map[string][]byte
+
+	// kv map holds the a map of k/v store
+	kv map[string][]byte
+}
+
 // SnapshotState is a struct holding a set of configs needed to take a snapshot.
 // This can be used by fsm (finite state machine) as an example.
 // See state_machine_test.go
 type SnapshotState struct {
 	// LogStore is the store holding the data
-	logStore rafty.Store
+	logStore rafty.LogStore
+
+	// userStore is only for user land management
+	userStore userLogInMemory
 }
 
 // CommandKind represent the command that will be applied to the state machine
@@ -258,9 +277,14 @@ func DecodeCommand(data []byte) (Command, error) {
 
 // NewSnapshotState return a SnapshotState that allow us to
 // take or restore snapshots
-func NewSnapshotState(logStore rafty.Store) *SnapshotState {
+func NewSnapshotState(logStore rafty.LogStore) *SnapshotState {
 	return &SnapshotState{
 		logStore: logStore,
+		userStore: userLogInMemory{
+			userStore: make(map[uint64]*rafty.LogEntry),
+			metadata:  make(map[string][]byte),
+			kv:        make(map[string][]byte),
+		},
 	}
 }
 
@@ -345,10 +369,10 @@ func (s *SnapshotState) ApplyCommand(cmd []byte) ([]byte, error) {
 	decodedCmd, _ := DecodeCommand(cmd)
 	switch decodedCmd.Kind {
 	case CommandSet:
-		return nil, s.logStore.Set([]byte(decodedCmd.Key), []byte(decodedCmd.Value))
+		return nil, s.userStore.Set([]byte(decodedCmd.Key), []byte(decodedCmd.Value))
 
 	case CommandGet:
-		value, err := s.logStore.Get([]byte(decodedCmd.Key))
+		value, err := s.userStore.Get([]byte(decodedCmd.Key))
 		if err != nil {
 			return nil, err
 		}
@@ -358,4 +382,48 @@ func (s *SnapshotState) ApplyCommand(cmd []byte) ([]byte, error) {
 		return nil, fmt.Errorf("not implemented yet")
 	}
 	return nil, nil
+}
+
+// Set will add key/value to the k/v store.
+// An error will be returned if necessary
+func (in *userLogInMemory) Set(key, value []byte) error {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+
+	in.kv[string(key)] = value
+	return nil
+}
+
+// Get will fetch provided key from the k/v store.
+// An error will be returned if the key is not found
+func (in *userLogInMemory) Get(key []byte) ([]byte, error) {
+	in.mu.RLock()
+	defer in.mu.RUnlock()
+
+	if val, ok := in.kv[string(key)]; ok {
+		return val, nil
+	}
+	return nil, rafty.ErrKeyNotFound
+}
+
+// Set will add key/value to the k/v store.
+// An error will be returned if necessary
+func (in *userLogInMemory) SetUint64(key, value []byte) error {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+
+	in.kv[string(key)] = value
+	return nil
+}
+
+// Get will fetch provided key from the k/v store.
+// An error will be returned if the key is not found
+func (in *userLogInMemory) GetUint64(key []byte) uint64 {
+	in.mu.RLock()
+	defer in.mu.RUnlock()
+
+	if val, ok := in.kv[string(key)]; ok {
+		return rafty.DecodeUint64ToBytes(val)
+	}
+	return 0
 }

--- a/examples/grpc/single-server-cluster/main.go
+++ b/examples/grpc/single-server-cluster/main.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/Lord-Y/rafty"
@@ -53,14 +54,14 @@ func main() {
 		log.Fatal(err)
 	}
 	cacheOptions := rafty.LogCacheOptions{
-		Store:        store,
+		LogStore:     store,
 		CacheOnWrite: true,
 		TTL:          2 * time.Second,
 	}
 	cacheStore := rafty.NewLogCache(cacheOptions)
 
 	fsm := NewSnapshotState(store)
-	s, err := rafty.NewRafty(addr, id, options, cacheStore, fsm, nil)
+	s, err := rafty.NewRafty(addr, id, options, cacheStore, store, fsm, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -112,13 +113,13 @@ func main() {
 						s.Logger.Fatal().Err(err).Msg("Fail to create sotre")
 					}
 					cacheOptions := rafty.LogCacheOptions{
-						Store:        store,
+						LogStore:     store,
 						CacheOnWrite: true,
 						TTL:          2 * time.Second,
 					}
 					cacheStore := rafty.NewLogCache(cacheOptions)
 					fsm := NewSnapshotState(cacheStore)
-					if s, err = rafty.NewRafty(addr, id, options, cacheStore, fsm, nil); err != nil {
+					if s, err = rafty.NewRafty(addr, id, options, cacheStore, store, fsm, nil); err != nil {
 						s.Logger.Fatal().Err(err).Msg("Fail to create cluster config")
 					}
 					if err := s.Start(); err != nil {
@@ -141,12 +142,30 @@ func main() {
 	}
 }
 
+// userLogInMemory hold the requirements related to user data
+type userLogInMemory struct {
+	// mu hold locking mecanism
+	mu sync.RWMutex
+
+	// userStore map holds a map of the log entries
+	userStore map[uint64]*rafty.LogEntry
+
+	// metadata map holds the a map of metadata store
+	metadata map[string][]byte
+
+	// kv map holds the a map of k/v store
+	kv map[string][]byte
+}
+
 // SnapshotState is a struct holding a set of configs needed to take a snapshot.
 // This can be used by fsm (finite state machine) as an example.
 // See state_machine_test.go
 type SnapshotState struct {
 	// LogStore is the store holding the data
-	logStore rafty.Store
+	logStore rafty.LogStore
+
+	// userStore is only for user land management
+	userStore userLogInMemory
 }
 
 // CommandKind represent the command that will be applied to the state machine
@@ -233,9 +252,14 @@ func DecodeCommand(data []byte) (Command, error) {
 
 // NewSnapshotState return a SnapshotState that allow us to
 // take or restore snapshots
-func NewSnapshotState(logStore rafty.Store) *SnapshotState {
+func NewSnapshotState(logStore rafty.LogStore) *SnapshotState {
 	return &SnapshotState{
 		logStore: logStore,
+		userStore: userLogInMemory{
+			userStore: make(map[uint64]*rafty.LogEntry),
+			metadata:  make(map[string][]byte),
+			kv:        make(map[string][]byte),
+		},
 	}
 }
 
@@ -320,10 +344,10 @@ func (s *SnapshotState) ApplyCommand(cmd []byte) ([]byte, error) {
 	decodedCmd, _ := DecodeCommand(cmd)
 	switch decodedCmd.Kind {
 	case CommandSet:
-		return nil, s.logStore.Set([]byte(decodedCmd.Key), []byte(decodedCmd.Value))
+		return nil, s.userStore.Set([]byte(decodedCmd.Key), []byte(decodedCmd.Value))
 
 	case CommandGet:
-		value, err := s.logStore.Get([]byte(decodedCmd.Key))
+		value, err := s.userStore.Get([]byte(decodedCmd.Key))
 		if err != nil {
 			return nil, err
 		}
@@ -333,4 +357,48 @@ func (s *SnapshotState) ApplyCommand(cmd []byte) ([]byte, error) {
 		return nil, fmt.Errorf("not implemented yet")
 	}
 	return nil, nil
+}
+
+// Set will add key/value to the k/v store.
+// An error will be returned if necessary
+func (in *userLogInMemory) Set(key, value []byte) error {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+
+	in.kv[string(key)] = value
+	return nil
+}
+
+// Get will fetch provided key from the k/v store.
+// An error will be returned if the key is not found
+func (in *userLogInMemory) Get(key []byte) ([]byte, error) {
+	in.mu.RLock()
+	defer in.mu.RUnlock()
+
+	if val, ok := in.kv[string(key)]; ok {
+		return val, nil
+	}
+	return nil, rafty.ErrKeyNotFound
+}
+
+// Set will add key/value to the k/v store.
+// An error will be returned if necessary
+func (in *userLogInMemory) SetUint64(key, value []byte) error {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+
+	in.kv[string(key)] = value
+	return nil
+}
+
+// Get will fetch provided key from the k/v store.
+// An error will be returned if the key is not found
+func (in *userLogInMemory) GetUint64(key []byte) uint64 {
+	in.mu.RLock()
+	defer in.mu.RUnlock()
+
+	if val, ok := in.kv[string(key)]; ok {
+		return rafty.DecodeUint64ToBytes(val)
+	}
+	return 0
 }

--- a/handlers.go
+++ b/handlers.go
@@ -68,7 +68,7 @@ func (r *Rafty) handleSendVoteRequest(data RPCRequest) {
 			Msgf("Vote granted to peer")
 
 		r.switchState(Follower, stepDown, true, request.CurrentTerm)
-		if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
+		if err := r.clusterStore.StoreMetadata(r.buildMetadata()); err != nil {
 			panic(err)
 		}
 		response.CurrentTerm = request.CurrentTerm
@@ -133,7 +133,7 @@ func (r *Rafty) handleSendVoteRequest(data RPCRequest) {
 				Msgf("Vote granted to peer")
 
 			r.switchState(Follower, stepDown, false, request.CurrentTerm)
-			if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
+			if err := r.clusterStore.StoreMetadata(r.buildMetadata()); err != nil {
 				panic(err)
 			}
 			data.ResponseChan <- rpcResponse
@@ -169,7 +169,7 @@ func (r *Rafty) handleSendVoteRequest(data RPCRequest) {
 		Msgf("Vote granted to peer")
 
 	r.switchState(Follower, stepDown, false, request.CurrentTerm)
-	if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
+	if err := r.clusterStore.StoreMetadata(r.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -244,7 +244,7 @@ func (r *Rafty) handleSendAppendEntriesRequest(data RPCRequest) {
 	}
 
 	r.currentTerm.Store(request.Term)
-	if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
+	if err := r.clusterStore.StoreMetadata(r.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -347,7 +347,7 @@ func (r *Rafty) handleSendAppendEntriesRequest(data RPCRequest) {
 						Msgf("Fail to apply config entry")
 				}
 			}
-			if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
+			if err := r.clusterStore.StoreMetadata(r.buildMetadata()); err != nil {
 				panic(err)
 			}
 
@@ -387,7 +387,7 @@ func (r *Rafty) handleSendAppendEntriesRequest(data RPCRequest) {
 				Str("lastAppliedConfigTerm", fmt.Sprintf("%d", r.lastAppliedConfigTerm.Load())).
 				Msgf("Node state index updated")
 
-			if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
+			if err := r.clusterStore.StoreMetadata(r.buildMetadata()); err != nil {
 				panic(err)
 			}
 		}

--- a/log_cache_test.go
+++ b/log_cache_test.go
@@ -26,7 +26,7 @@ func TestLogCache(t *testing.T) {
 		assert.Nil(err)
 
 		cacheOptions := LogCacheOptions{
-			Store:        store,
+			LogStore:     store,
 			CacheOnWrite: true,
 			TTL:          2 * time.Second,
 		}
@@ -61,7 +61,7 @@ func TestLogCache(t *testing.T) {
 		assert.Nil(err)
 
 		cacheOptions := LogCacheOptions{
-			Store:        store,
+			LogStore:     store,
 			CacheOnWrite: true,
 			TTL:          2 * time.Second,
 		}
@@ -108,7 +108,7 @@ func TestLogCache(t *testing.T) {
 		assert.Nil(err)
 
 		cacheOptions := LogCacheOptions{
-			Store:        store,
+			LogStore:     store,
 			CacheOnWrite: true,
 			TTL:          2 * time.Second,
 		}
@@ -150,7 +150,7 @@ func TestLogCache(t *testing.T) {
 		assert.Nil(err)
 
 		cacheOptions := LogCacheOptions{
-			Store:        store,
+			LogStore:     store,
 			CacheOnWrite: true,
 			TTL:          2 * time.Second,
 		}
@@ -194,7 +194,7 @@ func TestLogCache(t *testing.T) {
 		assert.Nil(err)
 
 		cacheOptions := LogCacheOptions{
-			Store:        store,
+			LogStore:     store,
 			CacheOnWrite: true,
 		}
 		cacheStore := NewLogCache(cacheOptions)
@@ -219,7 +219,7 @@ func TestLogCache(t *testing.T) {
 		assert.Nil(err)
 
 		cacheOptions := LogCacheOptions{
-			Store:        store,
+			LogStore:     store,
 			CacheOnWrite: true,
 			TTL:          2 * time.Second,
 		}
@@ -267,124 +267,5 @@ func TestLogCache(t *testing.T) {
 		l, err = cacheStore.LastIndex()
 		assert.Nil(err)
 		assert.Equal(last, l)
-	})
-
-	t.Run("cache_metadata", func(t *testing.T) {
-		boltOptions := BoltOptions{
-			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_metadata"),
-			Options: bbolt.DefaultOptions,
-		}
-
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-		}()
-		store, err := NewBoltStorage(boltOptions)
-		assert.Nil(err)
-
-		cacheOptions := LogCacheOptions{
-			Store:        store,
-			CacheOnWrite: true,
-			TTL:          2 * time.Second,
-		}
-		cacheStore := NewLogCache(cacheOptions)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(cacheStore.Close())
-		}()
-
-		s := basicNodeSetup()
-		defer func() {
-			assert.Nil(s.logStore.Close())
-			assert.Nil(os.RemoveAll(getRootDir(s.options.DataDir)))
-		}()
-		s.currentTerm.Store(1)
-		s.lastApplied.Store(1)
-
-		_, err = cacheStore.GetMetadata()
-		assert.Error(err)
-
-		assert.Nil(cacheStore.StoreMetadata(s.buildMetadata()))
-
-		time.Sleep(time.Second)
-		_, err = cacheStore.GetMetadata()
-		assert.Nil(err)
-
-		time.Sleep(2 * time.Second)
-		_, err = cacheStore.GetMetadata()
-		assert.Nil(err)
-	})
-
-	t.Run("cache_set_get", func(t *testing.T) {
-		boltOptions := BoltOptions{
-			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_set_get"),
-			Options: bbolt.DefaultOptions,
-		}
-
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-		}()
-		store, err := NewBoltStorage(boltOptions)
-		assert.Nil(err)
-
-		cacheOptions := LogCacheOptions{
-			Store:        store,
-			CacheOnWrite: true,
-			TTL:          2 * time.Second,
-		}
-		cacheStore := NewLogCache(cacheOptions)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(cacheStore.Close())
-		}()
-
-		key, value := []byte("key"), []byte("value")
-		_, err = cacheStore.Get(key)
-		assert.Error(err)
-
-		assert.Nil(cacheStore.Set(key, value))
-
-		time.Sleep(time.Second)
-		_, err = cacheStore.Get(key)
-		assert.Nil(err)
-
-		time.Sleep(2 * time.Second)
-		_, err = cacheStore.Get(key)
-		assert.Nil(err)
-	})
-
-	t.Run("cache_uint64_set_get", func(t *testing.T) {
-		boltOptions := BoltOptions{
-			DataDir: filepath.Join(os.TempDir(), "rafty_test", "cache_uint64_set_get"),
-			Options: bbolt.DefaultOptions,
-		}
-
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-		}()
-		store, err := NewBoltStorage(boltOptions)
-		assert.Nil(err)
-
-		cacheOptions := LogCacheOptions{
-			Store:        store,
-			CacheOnWrite: true,
-			TTL:          2 * time.Second,
-		}
-		cacheStore := NewLogCache(cacheOptions)
-		defer func() {
-			assert.Nil(os.RemoveAll(getRootDir(boltOptions.DataDir)))
-			assert.Nil(cacheStore.Close())
-		}()
-
-		key, value := "key", uint64(64)
-		result := cacheStore.GetUint64([]byte(key))
-		assert.Equal(uint64(0), result)
-
-		assert.Nil(cacheStore.SetUint64([]byte(key), EncodeUint64ToBytes(value)))
-
-		time.Sleep(time.Second)
-		assert.Equal(value, cacheStore.GetUint64([]byte(key)))
-
-		time.Sleep(2 * time.Second)
-		assert.Equal(value, cacheStore.GetUint64([]byte(key)))
 	})
 }

--- a/log_cache_types.go
+++ b/log_cache_types.go
@@ -17,8 +17,8 @@ type cacheItem struct {
 // LogCacheOptions hold all cache options that will be later
 // used by LogCache
 type LogCacheOptions struct {
-	// Store hold the long term storage data
-	Store Store
+	// LogStore hold the long term storage data related to raft logs
+	LogStore LogStore
 
 	// CacheOnWrite when set to true will put every write
 	// request in cache before writting to the long term storage
@@ -37,18 +37,12 @@ type LogCache struct {
 	// logs map holds a map of the log entries
 	logs map[string]*cacheItem
 
-	// metadata map holds the a map of metadata store
-	metadata map[string]*cacheItem
-
-	// kv map holds the a map of k/v store
-	kv map[string]*cacheItem
-
 	// cacheOnWrite when set to true will put every write
 	// request in cache before writting to the long term storage
 	cacheOnWrite bool
 
-	// store hold the long term storage data
-	store Store
+	// logStore hold the long term storage data related to raft logs
+	logStore LogStore
 
 	// ttl is the maximum amount of time to keep the entry in cache.
 	// Default to 30 seconds if ttl == 0

--- a/log_in_memory.go
+++ b/log_in_memory.go
@@ -7,9 +7,7 @@ import (
 
 func NewInMemoryStorage() *LogInMemory {
 	return &LogInMemory{
-		logs:     make(map[uint64]*LogEntry),
-		metadata: make(map[string][]byte),
-		kv:       make(map[string][]byte),
+		logs: make(map[uint64]*LogEntry),
 	}
 }
 
@@ -19,8 +17,6 @@ func (in *LogInMemory) Close() error {
 	defer in.mu.Unlock()
 
 	in.logs = nil
-	in.metadata = nil
-	in.kv = nil
 
 	return nil
 }
@@ -131,68 +127,4 @@ func (in *LogInMemory) LastIndex() (uint64, error) {
 		return keys[entry], nil
 	}
 	return 0, ErrKeyNotFound
-}
-
-// GetMetadata will fetch rafty metadata from the k/v store
-func (in *LogInMemory) GetMetadata() ([]byte, error) {
-	in.mu.RLock()
-	defer in.mu.RUnlock()
-
-	if val, ok := in.metadata["rafty_metadata"]; ok {
-		return val, nil
-	}
-	return nil, ErrKeyNotFound
-}
-
-// StoreMetadata will store rafty metadata into the k/v bucket
-func (in *LogInMemory) StoreMetadata(value []byte) error {
-	in.mu.Lock()
-	defer in.mu.Unlock()
-
-	in.metadata["rafty_metadata"] = value
-	return nil
-}
-
-// Set will add key/value to the k/v store.
-// An error will be returned if necessary
-func (in *LogInMemory) Set(key, value []byte) error {
-	in.mu.Lock()
-	defer in.mu.Unlock()
-
-	in.kv[string(key)] = value
-	return nil
-}
-
-// Get will fetch provided key from the k/v store.
-// An error will be returned if the key is not found
-func (in *LogInMemory) Get(key []byte) ([]byte, error) {
-	in.mu.RLock()
-	defer in.mu.RUnlock()
-
-	if val, ok := in.kv[string(key)]; ok {
-		return val, nil
-	}
-	return nil, ErrKeyNotFound
-}
-
-// Set will add key/value to the k/v store.
-// An error will be returned if necessary
-func (in *LogInMemory) SetUint64(key, value []byte) error {
-	in.mu.Lock()
-	defer in.mu.Unlock()
-
-	in.kv[string(key)] = value
-	return nil
-}
-
-// Get will fetch provided key from the k/v store.
-// An error will be returned if the key is not found
-func (in *LogInMemory) GetUint64(key []byte) uint64 {
-	in.mu.RLock()
-	defer in.mu.RUnlock()
-
-	if val, ok := in.kv[string(key)]; ok {
-		return DecodeUint64ToBytes(val)
-	}
-	return 0
 }

--- a/log_in_memory_test.go
+++ b/log_in_memory_test.go
@@ -1,9 +1,7 @@
 package rafty
 
 import (
-	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -140,62 +138,5 @@ func TestLogInMemory(t *testing.T) {
 		l, err := store.LastIndex()
 		assert.Nil(err)
 		assert.Equal(last, l)
-	})
-
-	t.Run("in_memory_metadata", func(t *testing.T) {
-		store := NewInMemoryStorage()
-		defer func() {
-			assert.Nil(store.Close())
-		}()
-
-		s := basicNodeSetup()
-		defer func() {
-			assert.Nil(s.logStore.Close())
-			assert.Nil(os.RemoveAll(getRootDir(s.options.DataDir)))
-		}()
-		s.currentTerm.Store(1)
-		s.lastApplied.Store(1)
-
-		_, err := store.GetMetadata()
-		assert.Error(err)
-
-		assert.Nil(store.StoreMetadata(s.buildMetadata()))
-		_, err = store.GetMetadata()
-		assert.Nil(err)
-	})
-
-	t.Run("in_memory_set_get", func(t *testing.T) {
-		store := NewInMemoryStorage()
-		defer func() {
-			assert.Nil(store.Close())
-		}()
-
-		key, value := []byte("key"), []byte("value")
-		_, err := store.Get(key)
-		assert.Error(err)
-
-		assert.Nil(store.Set(key, value))
-
-		time.Sleep(time.Second)
-		_, err = store.Get(key)
-		assert.Nil(err)
-
-		time.Sleep(2 * time.Second)
-		_, err = store.Get(key)
-		assert.Nil(err)
-	})
-
-	t.Run("in_memory_uint64_set_get", func(t *testing.T) {
-		store := NewInMemoryStorage()
-		defer func() {
-			assert.Nil(store.Close())
-		}()
-
-		key, value := "key", uint64(64)
-		result := store.GetUint64([]byte(key))
-		assert.Equal(uint64(0), result)
-
-		assert.Nil(store.SetUint64([]byte(key), EncodeUint64ToBytes(value)))
-		assert.Equal(value, store.GetUint64([]byte(key)))
 	})
 }

--- a/log_in_memory_types.go
+++ b/log_in_memory_types.go
@@ -11,10 +11,4 @@ type LogInMemory struct {
 
 	// logs map holds a map of the log entries
 	logs map[uint64]*LogEntry
-
-	// metadata map holds the a map of metadata store
-	metadata map[string][]byte
-
-	// kv map holds the a map of k/v store
-	kv map[string][]byte
 }

--- a/logs_persistant_types.go
+++ b/logs_persistant_types.go
@@ -15,6 +15,7 @@ const (
 	bucketKVName string = "rafty_kv"
 )
 
+// BoltOptions is all requirements related to boltdb
 type BoltOptions struct {
 	// DataDir is the default data directory that will be used to store all data on the disk. It's required
 	DataDir string
@@ -32,38 +33,11 @@ type BoltStore struct {
 	db *bolt.DB
 }
 
-// Store is an interface that allow us to store and retrieve
-// logs from memory
-type Store interface {
+// ClusterStore is an interface that allow us to store and retrieve
+// data only for cluster related purpose
+type ClusterStore interface {
 	// Close permits to close the store
 	Close() error
-
-	// StoreLogs stores multiple log entries
-	StoreLogs(logs []*LogEntry) error
-
-	// StoreLog stores a single log entry
-	StoreLog(log *LogEntry) error
-
-	// GetLogByIndex permits to retrieve log from specified index
-	GetLogByIndex(index uint64) (*LogEntry, error)
-
-	// GetLogsByRange will return a slice of logs
-	// with peer lastLogIndex and leader lastLogIndex capped
-	// by options.MaxAppendEntries
-	GetLogsByRange(peerLastLogIndex, leaderLastLogIndex, maxAppendEntries uint64) GetLogsByRangeResponse
-
-	// GetLastConfiguration returns the last configuration found
-	// in logs
-	GetLastConfiguration() (*LogEntry, error)
-
-	// DiscardLogs permits to wipe entries with the provided range indexes
-	DiscardLogs(from, to uint64) error
-
-	// FistIndex will return the first index from the raft log
-	FirstIndex() (uint64, error)
-
-	// LastIndex will return the last index from the raft log
-	LastIndex() (uint64, error)
 
 	// GetMetadata will fetch rafty metadata from the k/v store
 	GetMetadata() ([]byte, error)
@@ -83,6 +57,40 @@ type Store interface {
 
 	// GetUint64 will fetch provided key from the k/v store
 	GetUint64(key []byte) uint64
+}
+
+// LogStore is an interface that allow us to store and retrieve
+// raft logs from memory
+type LogStore interface {
+	// Close permits to close the store
+	Close() error
+
+	// StoreLogs stores multiple log entries
+	StoreLogs(logs []*LogEntry) error
+
+	// StoreLog stores a single log entry
+	StoreLog(log *LogEntry) error
+
+	// GetLogByIndex permits to retrieve log from specified index
+	GetLogByIndex(index uint64) (*LogEntry, error)
+
+	// GetLogsByRange will return a slice of logs
+	// with peer lastLogIndex and leader lastLogIndex capped
+	// by options.MaxAppendEntries
+	GetLogsByRange(peerLastLogIndex, leaderLastLogIndex, maxAppendEntries uint64) GetLogsByRangeResponse
+
+	// DiscardLogs permits to wipe entries with the provided range indexes
+	DiscardLogs(from, to uint64) error
+
+	// FistIndex will return the first index from the raft log
+	FirstIndex() (uint64, error)
+
+	// LastIndex will return the last index from the raft log
+	LastIndex() (uint64, error)
+
+	// GetLastConfiguration returns the last configuration found
+	// in logs
+	GetLastConfiguration() (*LogEntry, error)
 }
 
 // GetLogsByRangeResponse returns response from GetLogsByRange func

--- a/membership.go
+++ b/membership.go
@@ -141,7 +141,7 @@ func (r *leader) addNode(member Peer, req *raftypb.MembershipChangeRequest, foll
 
 	if !r.rafty.isPartOfTheCluster(member) {
 		_ = r.rafty.applyConfigEntry(entries[0])
-		if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
+		if err := r.rafty.clusterStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 			panic(err)
 		}
 
@@ -257,7 +257,7 @@ func (r *leader) promoteNode(action MembershipChange, member Peer, follower *fol
 	}
 
 	_ = r.rafty.applyConfigEntry(entries[0])
-	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.clusterStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -318,7 +318,7 @@ func (r *leader) demoteNode(action MembershipChange, member Peer) (success bool,
 	}
 
 	_ = r.rafty.applyConfigEntry(entries[0])
-	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.clusterStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -399,7 +399,7 @@ func (r *leader) removeNode(action MembershipChange, member Peer) (success bool,
 	}
 
 	_ = r.rafty.applyConfigEntry(entries[0])
-	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.clusterStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 

--- a/rafty_types.go
+++ b/rafty_types.go
@@ -314,8 +314,30 @@ type Rafty struct {
 	// logs allow us to manipulate logs
 	logs logs
 
-	// logStore is long term storage backend of raft
-	logStore Store
+	// logStore is long term storage backend only for raft logs.
+	// The same long term storage for clusterStore and logStore can be used
+	// BUT in different namespace or buckets to avoid collisions.
+	// In logs_persistant_types, you will see different buckets for bolt storage:
+	// - bucketLogsName
+	// - bucketMetadataName
+	// - bucketKVName
+	// The same logic is applied for LogCache and LogInMemory.
+	// User land MUST NOT modified those logs.
+	// Users must use their own buckets with stateMachine when use ApplyCommand.
+	logStore LogStore
+
+	// clusterStore is long term storage backend only for the raft cluster
+	// purpose like metadata and other KVs e.g.
+	// The same long term storage for clusterStore and logStore can be used
+	// BUT in different namespace or buckets to avoid collisions.
+	// In logs_persistant_types, you will see different buckets for bolt storage:
+	// - bucketLogsName
+	// - bucketMetadataName
+	// - bucketKVName
+	// The same logic is applied for LogCache and LogInMemory.
+	// User land MUST NOT modified those entries.
+	// Users must use their own buckets with stateMachine when use ApplyCommand.
+	clusterStore ClusterStore
 
 	// snapshot hold the configuration to manage snapshots
 	snapshot SnapshotStore

--- a/rafty_utils_test.go
+++ b/rafty_utils_test.go
@@ -62,7 +62,7 @@ func basicNodeSetup() *Rafty {
 		log.Fatal(err)
 	}
 	fsm := NewSnapshotState(store)
-	s, err := NewRafty(addr, id, options, store, fsm, nil)
+	s, err := NewRafty(addr, id, options, store, store, fsm, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func singleServerClusterSetup(address string) *Rafty {
 	}
 	fsm := NewSnapshotState(store)
 	snapshot := NewSnapshot(options.DataDir, 3) // only forced here for more unit testing coverage
-	s, err := NewRafty(addr, id, options, store, fsm, snapshot)
+	s, err := NewRafty(addr, id, options, store, store, fsm, snapshot)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func (cc *clusterConfig) makeCluster() (cluster []*Rafty) {
 		store, err := NewBoltStorage(storeOptions)
 		cc.assert.Nil(err)
 		fsm := NewSnapshotState(store)
-		server, err := NewRafty(addr, id, options, store, fsm, nil)
+		server, err := NewRafty(addr, id, options, store, store, fsm, nil)
 		cc.assert.Nil(err)
 		cluster = append(cluster, server)
 		return
@@ -237,7 +237,7 @@ func (cc *clusterConfig) makeCluster() (cluster []*Rafty) {
 				// duplicate metrics collector registration attempted
 				options.MetricsNamespacePrefix = fmt.Sprintf("%s_%s_%s", cc.testName, id, fake.CharactersN(100))
 				fsm := NewSnapshotState(store)
-				server, err = NewRafty(addr, id, options, store, fsm, nil)
+				server, err = NewRafty(addr, id, options, store, store, fsm, nil)
 				cc.assert.Nil(err)
 			}
 		}
@@ -275,7 +275,7 @@ func (cc *clusterConfig) makeAdditionalNode(readReplica, shutdownOnRemove, leave
 	store, err := NewBoltStorage(storeOptions)
 	cc.assert.Nil(err)
 	fsm := NewSnapshotState(store)
-	r, err := NewRafty(addr, id, options, store, fsm, nil)
+	r, err := NewRafty(addr, id, options, store, store, fsm, nil)
 	cc.assert.Nil(err)
 	cc.newNodes = append(cc.newNodes, r)
 }
@@ -412,7 +412,7 @@ func (cc *clusterConfig) restartNode(nodeId int, wg *sync.WaitGroup) {
 				store, err := NewBoltStorage(storeOptions)
 				cc.assert.Nil(err)
 				fsm := NewSnapshotState(store)
-				node, err := NewRafty(address, id, options, store, fsm, nil)
+				node, err := NewRafty(address, id, options, store, store, fsm, nil)
 				cc.assert.Nil(err)
 				cc.cluster[nodeId] = node
 				cc.mu.Unlock()

--- a/rpcs.go
+++ b/rpcs.go
@@ -541,7 +541,7 @@ func (r *Rafty) bootstrapCluster(data RPCRequest) {
 		panic(err)
 	}
 	_ = r.applyConfigEntry(entries[0])
-	if err := r.logStore.StoreMetadata(r.buildMetadata()); err != nil {
+	if err := r.clusterStore.StoreMetadata(r.buildMetadata()); err != nil {
 		panic(err)
 	}
 

--- a/state_candidate.go
+++ b/state_candidate.go
@@ -121,7 +121,7 @@ func (r *candidate) handlePreVoteResponse(resp RPCResponse) {
 	if response.CurrentTerm > response.RequesterTerm {
 		r.rafty.currentTerm.Store(response.CurrentTerm)
 		r.rafty.switchState(Follower, stepDown, false, response.CurrentTerm)
-		if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
+		if err := r.rafty.clusterStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 			panic(err)
 		}
 		return
@@ -149,7 +149,7 @@ func (r *candidate) handlePreVoteResponse(resp RPCResponse) {
 // to other nodes in order to elect a leader
 func (r *candidate) startElection() {
 	currentTerm := r.rafty.currentTerm.Add(1)
-	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.clusterStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 
@@ -226,7 +226,7 @@ func (r *candidate) handleVoteResponse(resp RPCResponse) {
 
 		r.rafty.currentTerm.Store(response.CurrentTerm)
 		r.rafty.switchState(Follower, stepDown, false, response.CurrentTerm)
-		if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
+		if err := r.rafty.clusterStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 			panic(err)
 		}
 		return
@@ -254,7 +254,7 @@ func (r *candidate) handleVoteResponse(resp RPCResponse) {
 func (r *candidate) isSingleServerCluster() {
 	currentTerm := r.rafty.currentTerm.Add(1)
 	r.rafty.switchState(Candidate, stepUp, true, currentTerm)
-	if err := r.rafty.logStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
+	if err := r.rafty.clusterStore.StoreMetadata(r.rafty.buildMetadata()); err != nil {
 		panic(err)
 	}
 	r.rafty.switchState(Leader, stepUp, true, currentTerm)

--- a/state_machine_test.go
+++ b/state_machine_test.go
@@ -7,15 +7,34 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 )
+
+// userLogInMemory hold the requirements related to user data
+type userLogInMemory struct {
+	// mu hold locking mecanism
+	mu sync.RWMutex
+
+	// userStore map holds a map of the log entries
+	userStore map[uint64]*LogEntry
+
+	// metadata map holds the a map of metadata store
+	metadata map[string][]byte
+
+	// kv map holds the a map of k/v store
+	kv map[string][]byte
+}
 
 // SnapshotState is a struct holding a set of configs needed to take a snapshot.
 // This can be used by fsm (finite state machine) as an example.
 // See state_machine_test.go
 type SnapshotState struct {
 	// LogStore is the store holding the data
-	logStore Store
+	logStore LogStore
+
+	// userStore is only for user land management
+	userStore userLogInMemory
 
 	applyErrTest error
 	sleepErr     time.Duration
@@ -105,9 +124,14 @@ func DecodeCommand(data []byte) (Command, error) {
 
 // NewSnapshotState return a SnapshotState that allow us to
 // take or restore snapshots
-func NewSnapshotState(logStore Store) *SnapshotState {
+func NewSnapshotState(logStore LogStore) *SnapshotState {
 	return &SnapshotState{
 		logStore: logStore,
+		userStore: userLogInMemory{
+			userStore: make(map[uint64]*LogEntry),
+			metadata:  make(map[string][]byte),
+			kv:        make(map[string][]byte),
+		},
 	}
 }
 
@@ -200,10 +224,10 @@ func (s *SnapshotState) ApplyCommand(cmd []byte) ([]byte, error) {
 	decodedCmd, _ := DecodeCommand(cmd)
 	switch decodedCmd.Kind {
 	case CommandSet:
-		return nil, s.logStore.Set([]byte(decodedCmd.Key), []byte(decodedCmd.Value))
+		return nil, s.userStore.Set([]byte(decodedCmd.Key), []byte(decodedCmd.Value))
 
 	case CommandGet:
-		value, err := s.logStore.Get([]byte(decodedCmd.Key))
+		value, err := s.userStore.Get([]byte(decodedCmd.Key))
 		if err != nil {
 			return nil, err
 		}
@@ -213,4 +237,48 @@ func (s *SnapshotState) ApplyCommand(cmd []byte) ([]byte, error) {
 		return nil, fmt.Errorf("not implemented yet")
 	}
 	return nil, nil
+}
+
+// Set will add key/value to the k/v store.
+// An error will be returned if necessary
+func (in *userLogInMemory) Set(key, value []byte) error {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+
+	in.kv[string(key)] = value
+	return nil
+}
+
+// Get will fetch provided key from the k/v store.
+// An error will be returned if the key is not found
+func (in *userLogInMemory) Get(key []byte) ([]byte, error) {
+	in.mu.RLock()
+	defer in.mu.RUnlock()
+
+	if val, ok := in.kv[string(key)]; ok {
+		return val, nil
+	}
+	return nil, ErrKeyNotFound
+}
+
+// Set will add key/value to the k/v store.
+// An error will be returned if necessary
+func (in *userLogInMemory) SetUint64(key, value []byte) error {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+
+	in.kv[string(key)] = value
+	return nil
+}
+
+// Get will fetch provided key from the k/v store.
+// An error will be returned if the key is not found
+func (in *userLogInMemory) GetUint64(key []byte) uint64 {
+	in.mu.RLock()
+	defer in.mu.RUnlock()
+
+	if val, ok := in.kv[string(key)]; ok {
+		return DecodeUint64ToBytes(val)
+	}
+	return 0
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -146,7 +146,7 @@ func TestUtils_parsePeers(t *testing.T) {
 	store, err := NewBoltStorage(storeOptions)
 	assert.Nil(err)
 	fsm := NewSnapshotState(store)
-	s, _ := NewRafty(addr, id, options, store, fsm, nil)
+	s, _ := NewRafty(addr, id, options, store, store, fsm, nil)
 
 	mergePeers := func(peers []InitialPeer) {
 		for _, v := range peers {


### PR DESCRIPTION
Related to github issue #49

Splitting the store is necessary to have a separation of duty. Users can still use the same store for both of them but will use different namespaces/buckets to avoid collisions. ClusterStore won't be modified that much so caching it won't be that necessary but still possible.