### PR TITLE
Add linearizable read

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Here is a list of the supported features of `rafty`:
   - [x] Log replication
   - [x] Submit write commands
   - [x] Submit read commands
+    - [x] Submit read commands linearizable
+    - [x] Submit read commands leader lease
   - [x] Forward read/write commands to leader
   - [x] Log compaction
 - [x] Log storage

--- a/log_replication_test.go
+++ b/log_replication_test.go
@@ -59,7 +59,7 @@ func TestLogReplication_SendCatchupAppendEntries(t *testing.T) {
 		followerRepl := &followerReplication{
 			Peer:         followers[id],
 			rafty:        s,
-			newEntryChan: make(chan bool),
+			newEntryChan: make(chan replicationData),
 		}
 		followerRepl.sendCatchupAppendEntries(client, oldRequest, oldResponse)
 		s.wg.Wait()
@@ -107,7 +107,7 @@ func TestLogReplication_SendCatchupAppendEntries(t *testing.T) {
 		followerRepl := &followerReplication{
 			Peer:         followers[id],
 			rafty:        s,
-			newEntryChan: make(chan bool),
+			newEntryChan: make(chan replicationData),
 		}
 		followerRepl.sendCatchupAppendEntries(client, oldRequest, oldResponse)
 		s.wg.Wait()
@@ -160,7 +160,7 @@ func TestLogReplication_SendCatchupAppendEntries(t *testing.T) {
 		followerRepl := &followerReplication{
 			Peer:         followers[id],
 			rafty:        s,
-			newEntryChan: make(chan bool),
+			newEntryChan: make(chan replicationData),
 		}
 		followerRepl.sendCatchupAppendEntries(client, oldRequest, oldResponse)
 		s.wg.Wait()
@@ -207,10 +207,10 @@ func TestLogReplication_catchupNewMember(t *testing.T) {
 		}
 
 		follower := &followerReplication{
-			Peer:         member,
-			rafty:        s,
-			newEntryChan: make(chan bool),
-			notifyLeader: state.commitChan,
+			Peer:             member,
+			rafty:            s,
+			newEntryChan:     make(chan replicationData),
+			notifyLeaderChan: state.commitChan,
 		}
 
 		buildResponse := &raftypb.AppendEntryResponse{
@@ -249,7 +249,7 @@ func TestLogReplication_sendInstallSnapshot(t *testing.T) {
 		followerRepl := &followerReplication{
 			Peer:         followers[id],
 			rafty:        s,
-			newEntryChan: make(chan bool),
+			newEntryChan: make(chan replicationData),
 		}
 		followerRepl.sendSnapshotInProgress.Store(true)
 		followerRepl.sendInstallSnapshot(client)
@@ -280,7 +280,7 @@ func TestLogReplication_sendInstallSnapshot(t *testing.T) {
 		followerRepl := &followerReplication{
 			Peer:         followers[id],
 			rafty:        s,
-			newEntryChan: make(chan bool),
+			newEntryChan: make(chan replicationData),
 		}
 		followerRepl.sendInstallSnapshot(client)
 		s.wg.Wait()
@@ -316,7 +316,7 @@ func TestLogReplication_sendInstallSnapshot(t *testing.T) {
 		followerRepl := &followerReplication{
 			Peer:         followers[id],
 			rafty:        s,
-			newEntryChan: make(chan bool),
+			newEntryChan: make(chan replicationData),
 		}
 		followerRepl.sendInstallSnapshot(client)
 		s.wg.Wait()
@@ -354,7 +354,7 @@ func TestLogReplication_sendInstallSnapshot(t *testing.T) {
 		followerRepl := &followerReplication{
 			Peer:         followers[id],
 			rafty:        s,
-			newEntryChan: make(chan bool),
+			newEntryChan: make(chan replicationData),
 		}
 		followerRepl.sendInstallSnapshot(mockClient)
 		s.wg.Wait()
@@ -394,7 +394,7 @@ func TestLogReplication_sendInstallSnapshot(t *testing.T) {
 		followerRepl := &followerReplication{
 			Peer:         followers[id],
 			rafty:        s,
-			newEntryChan: make(chan bool),
+			newEntryChan: make(chan replicationData),
 		}
 		followerRepl.sendInstallSnapshot(mockClient)
 		s.wg.Wait()

--- a/log_replication_types.go
+++ b/log_replication_types.go
@@ -30,10 +30,10 @@ type followerReplication struct {
 	rafty *Rafty
 
 	// newEntry is used by the leader to trigger log replication or hearbeat
-	newEntryChan chan bool
+	newEntryChan chan replicationData
 
-	// notifyLeader is used once nextIndex/matchIndex has updated
-	notifyLeader chan commitChanConfig
+	// notifyLeaderChan is used once nextIndex/matchIndex has updated
+	notifyLeaderChan chan commitChanConfig
 
 	// replicationStopped is used by the leader
 	// to stop ongoing append entries replication
@@ -100,4 +100,28 @@ type onAppendEntriesRequest struct {
 
 	// membershipChangeID is the id of the member to take action on
 	membershipChangeID string
+}
+
+// replicationData holds basic requirements
+// to replicate data
+type replicationData struct {
+	// uuid is used only for debugging.
+	// It helps to differenciate append entries requests
+	uuid string
+
+	// heartbeat is a boolean indicating to it's use to keep leadership
+	heartbeat bool
+
+	// newKey is a boolean indicating to it's use to keep leadership
+	newKey bool
+
+	// readIndex is used to indicate if we need to perform a linearizable
+	// read. It's a special heartbeat
+	readIndex bool
+
+	// commitIndex is only set when readIndex is true
+	commitIndex uint64
+
+	// term is only set when readIndex is true
+	term uint64
 }

--- a/logs.go
+++ b/logs.go
@@ -15,8 +15,10 @@ func (s LogKind) String() string {
 		return "logConfiguration"
 	case LogReplication:
 		return "logReplication"
-	case LogCommandReadLeader:
-		return "logCommandReadLeader"
+	case LogCommandReadLeaderLease:
+		return "logCommandReadLeaderLease"
+	case LogCommandLinearizableRead:
+		return "logCommandLinearizableRead"
 	}
 	return "logNoop"
 }

--- a/logs_test.go
+++ b/logs_test.go
@@ -27,13 +27,15 @@ func TestLogs(t *testing.T) {
 			LogNoop,
 			LogConfiguration,
 			LogReplication,
-			LogCommandReadLeader,
+			LogCommandReadLeaderLease,
+			LogCommandLinearizableRead,
 		}
 		results := []string{
 			"logNoop",
 			"logConfiguration",
 			"logReplication",
-			"logCommandReadLeader",
+			"logCommandReadLeaderLease",
+			"logCommandLinearizableRead",
 		}
 
 		for k, v := range tests {

--- a/logs_types.go
+++ b/logs_types.go
@@ -21,8 +21,14 @@ const (
 	// on all nodes
 	LogReplication
 
-	// logCommanRead is a log type use by clients to fetch data from the leader
-	LogCommandReadLeader
+	// LogCommandReadLeaderLease is a log type use by clients to fetch data from the leader.
+	// This mode is susceptible to time drift or long GC pause.
+	// Use this method only if you don't mind to potentially have stale data
+	LogCommandReadLeaderLease
+
+	// LogCommandLinearizableRead is a command that guarantees read data validity.
+	// No stale read can happen in this mode.
+	LogCommandLinearizableRead
 )
 
 // logs holds all requirements to manipulate logs

--- a/rafty_utils_test.go
+++ b/rafty_utils_test.go
@@ -428,10 +428,17 @@ func (cc *clusterConfig) submitCommandOnAllNodes(wg *sync.WaitGroup) {
 				if err := EncodeCommand(Command{Kind: CommandGet, Key: key}, bufferRead); err != nil {
 					node.Logger.Fatal().Err(err).Msgf("Fail to encode command %d", i)
 				}
-				if _, err := node.SubmitCommand(0, LogCommandReadLeader, bufferRead.Bytes()); err != nil {
+				if _, err := node.SubmitCommand(0, LogCommandReadLeaderLease, bufferRead.Bytes()); err != nil {
 					node.Logger.Error().Err(err).
 						Str("node", node.id).
-						Str("logType", LogCommandReadLeader.String()).
+						Str("logType", LogCommandReadLeaderLease.String()).
+						Msgf("Failed to submit commmand to node")
+					cc.assert.Error(err)
+				}
+				if _, err := node.SubmitCommand(5*time.Second, LogCommandLinearizableRead, bufferRead.Bytes()); err != nil {
+					node.Logger.Error().Err(err).
+						Str("node", node.id).
+						Str("logType", LogCommandLinearizableRead.String()).
 						Msgf("Failed to submit commmand to node")
 					cc.assert.Error(err)
 				}


### PR DESCRIPTION
This allow end user to always have no stale data.
Otherwise an error will be return to end user so it can retry.
Implements https://github.com/Lord-Y/rafty/issues/69